### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ data/clinton-trump-tweets.zip: dataset from kaggle
 
 To import and run the notebook in our Data Science experience platform, follow the setup instructions here:
 https://github.com/IBMDataScience/getting-started
+
+_When setting up our DSX tool, choose the Jupyter bundle that includes R support to process this notebook._


### PR DESCRIPTION
This notebook requires R packages to be available within the Jupyter Python kernel used inside DSX. When accepting a default configuration of DSX at install time, R support is excluded. It might make more sense to add such information every other tutorial so the reader is aware of such special requirements, on top of the default info ? Thanks.